### PR TITLE
fix VSG installation script

### DIFF
--- a/contrib/build-scripts/linux/buildVSG.sh
+++ b/contrib/build-scripts/linux/buildVSG.sh
@@ -91,7 +91,7 @@ echo "  "  ${ASSIMP_SOURCE_DIR}
 # ------------------------------------------------------------------------
 
 rm -rf ${VSG_INSTALL_DIR}
-mkdir ${VSG_INSTALL_DIR}
+mkdir -p ${VSG_INSTALL_DIR}
 
 # --- assimp -------------------------------------------------------------
 

--- a/contrib/build-scripts/linux/buildVSG.sh
+++ b/contrib/build-scripts/linux/buildVSG.sh
@@ -56,7 +56,7 @@ then
     echo "Download sources from GitHub"
 
     rm -rf download_vsg
-    mkdir download_vsg
+    mkdir -p download_vsg
 
     echo "  ... VulkanSceneGraph"
     git clone -c advice.detachedHead=false --depth 1 --branch v1.1.4 "https://github.com/vsg-dev/VulkanSceneGraph" "download_vsg/vsg"


### PR DESCRIPTION
When I was installing via `contrib/build-scripts/linux/buildVSG.sh`, I got error:

```sh
mkdir: cannot create directory ‘/home/zhengxiao-han/Packages/vsg’: No such file or directory
```

The commit I made can fix this error.