### PR TITLE
Make it pass compiling in Ubuntu 24.04

### DIFF
--- a/contrib/build-scripts/linux/buildVSG.sh
+++ b/contrib/build-scripts/linux/buildVSG.sh
@@ -104,7 +104,8 @@ cmake -G "${BUILDSYSTEM}" -B build_assimp -S ${ASSIMP_SOURCE_DIR} \
       -DASSIMP_BUILD_TESTS:BOOL=OFF  \
       -DASSIMP_BUILD_ASSIMP_TOOLS:BOOL=OFF \
       -DASSIMP_BUILD_ZLIB:BOOL=ON \
-      -DASSIMP_BUILD_DRACO:BOOL=ON
+      -DASSIMP_BUILD_DRACO:BOOL=ON \
+      -DASSIMP_WARNINGS_AS_ERRORS=OFF \
 
 echo -e "\n------------------------ Build and install assimp\n"
 cmake --build build_assimp --config Release


### PR DESCRIPTION
I got errors:

```sh
[249/350] Building CXX object code/CMakeFiles/assimp.dir/Release/AssetLib/IFC/IFCReaderGen1_2x3.cpp.o
ninja: build stopped: subcommand failed.
-- Installing: /home/zhengxiao-han/Packages/vsg/lib/cmake/assimp-5.3/assimpConfig.cmake
-- Installing: /home/zhengxiao-han/Packages/vsg/lib/cmake/assimp-5.3/assimpConfigVersion.cmake
-- Installing: /home/zhengxiao-han/Packages/vsg/lib/cmake/assimp-5.3/assimpTargets.cmake
-- Installing: /home/zhengxiao-han/Packages/vsg/lib/cmake/assimp-5.3/assimpTargets-release.cmake
-- Installing: /home/zhengxiao-han/Packages/vsg/lib/libdraco.a
-- Installing: /home/zhengxiao-han/Packages/vsg/lib/pkgconfig/assimp.pc
-- Installing: /home/zhengxiao-han/Packages/vsg/lib/libzlibstatic.a
CMake Error at build_assimp/code/cmake_install.cmake:49 (file):
  file INSTALL cannot find
  "/home/zhengxiao-han/projects/chrono/contrib/build-scripts/linux/build_assimp/lib/Release/libassimp.a":
  No such file or directory.
Call Stack (most recent call first):
  build_assimp/cmake_install.cmake:98 (include)


No Debug build of assimp
```

when I was compiling in Ubuntu 24.04. However after adding 
```sh
-DASSIMP_WARNINGS_AS_ERRORS=OFF
```
into `buildVSG.sh` the error disappeared and the building script passed.